### PR TITLE
Upgraded to Google Play Billing Library 7

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import com.android.Version
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
@@ -22,7 +24,7 @@ buildscript {
     if (ext.has("kotlinVersion")) {
       ext.kotlinVersion()
     } else {
-      ext.safeExtGet("kotlinVersion", "1.8.10")
+      ext.safeExtGet("kotlinVersion", "1.9.20")
     }
   }
 
@@ -44,7 +46,7 @@ afterEvaluate {
     }
     repositories {
       maven {
-        url = mavenLocal().url
+        url = maven().url
       }
     }
   }
@@ -53,8 +55,8 @@ afterEvaluate {
 android {
   // Remove this if and it's contents, when support for SDK49 is dropped
   if (!safeExtGet("expoProvidesDefaultConfig", false)) {
-    compileSdkVersion safeExtGet("compileSdkVersion", 33)
-    
+    compileSdk safeExtGet("compileSdkVersion", 33)
+
     defaultConfig {
       minSdkVersion safeExtGet("minSdkVersion", 23)
       targetSdkVersion safeExtGet("targetSdkVersion", 33)
@@ -65,7 +67,7 @@ android {
     }
   }
 
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  def agpVersion = Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() < 8) {
     compileOptions {
       sourceCompatibility JavaVersion.VERSION_11
@@ -97,9 +99,9 @@ allprojects {
 }
 
 dependencies {
-  implementation 'androidx.annotation:annotation:1.1.0'
+  implementation 'androidx.annotation:annotation:1.8.2'
   implementation project(':expo-modules-core')
-  api 'com.android.billingclient:billing:5.0.0'
+  api 'com.android.billingclient:billing:7.0.0'
 
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,9 +45,7 @@ afterEvaluate {
       }
     }
     repositories {
-      maven {
-        url = maven().url
-      }
+      mavenLocal()
     }
   }
 }

--- a/android/src/main/java/expo/modules/inapppurchases/InAppPurchasesModule.java
+++ b/android/src/main/java/expo/modules/inapppurchases/InAppPurchasesModule.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import android.content.Context;
 import android.app.Activity;
-import android.util.Log;
 
 import expo.modules.core.ExportedModule;
 import expo.modules.core.ModuleRegistry;
@@ -16,13 +15,10 @@ import expo.modules.core.interfaces.RegistryLifecycleListener;
 import expo.modules.core.interfaces.services.EventEmitter;
 
 public class InAppPurchasesModule extends ExportedModule implements RegistryLifecycleListener {
-  private static final String TAG = InAppPurchasesModule.class.getSimpleName();
   private static final String NAME = "ExpoInAppPurchases";
-  private final String USE_GOOGLE_PLAY_CACHE_KEY = "useGooglePlayCache";
 
   private BillingManager mBillingManager;
   private ModuleRegistry mModuleRegistry;
-  private EventEmitter mEventEmitter;
 
   public InAppPurchasesModule(Context context) {
     super(context);
@@ -38,41 +34,52 @@ public class InAppPurchasesModule extends ExportedModule implements RegistryLife
     mModuleRegistry = moduleRegistry;
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void connectAsync(final Promise promise) {
     Activity activity = getCurrentActivity();
     if (activity == null) {
       promise.reject("E_ACTIVITY_UNAVAILABLE", "Activity is not available");
     }
-    mEventEmitter = mModuleRegistry.getModule(EventEmitter.class);
+    EventEmitter mEventEmitter = mModuleRegistry.getModule(EventEmitter.class);
     mBillingManager = new BillingManager(activity, mEventEmitter);
     mBillingManager.startConnection(promise);
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void getProductsAsync(List<String> itemList, final Promise promise) {
     mBillingManager.queryPurchasableItems(itemList, promise);
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void getPurchaseHistoryAsync(final ReadableArguments options, final Promise promise) {
+    String USE_GOOGLE_PLAY_CACHE_KEY = "useGooglePlayCache";
     if (options.getBoolean(USE_GOOGLE_PLAY_CACHE_KEY, true)) {
       mBillingManager.queryPurchases(promise);
-    } else {
-      mBillingManager.queryPurchaseHistoryAsync(promise);
     }
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void purchaseItemAsync(String skuId, ReadableArguments details, final Promise promise) {
     mBillingManager.purchaseItemAsync(skuId, details, promise);
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void getBillingResponseCodeAsync(final Promise promise) {
     promise.resolve(mBillingManager.getBillingClientResponseCode());
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void finishTransactionAsync(String purchaseToken, Boolean consume, final Promise promise) {
     if (consume != null && consume) {
@@ -82,6 +89,8 @@ public class InAppPurchasesModule extends ExportedModule implements RegistryLife
     }
   }
 
+  // Suppressing "unused" warning because this method is exposed to React Native
+  @SuppressWarnings("unused")
   @ExpoMethod
   public void disconnectAsync(final Promise promise) {
     if (mBillingManager != null) {

--- a/android/src/main/java/expo/modules/inapppurchases/UpdateListener.java
+++ b/android/src/main/java/expo/modules/inapppurchases/UpdateListener.java
@@ -16,8 +16,7 @@ import expo.modules.core.Promise;
  * Handler to billing updates
  */
 public class UpdateListener implements BillingManager.BillingUpdatesListener {
-  private static final String TAG = "UpdateListener";
-  private EventEmitter mEventEmitter;
+  private final EventEmitter mEventEmitter;
 
   public UpdateListener(EventEmitter eventEmitter) {
     mEventEmitter = eventEmitter;


### PR DESCRIPTION
## Updates

- I updated some deprecated methods in the build.gradle file to ensure compatibility with the latest Google API versions.
- I updated the BillingClient to work with ProductDetails (and all its derivative forms) instead of SkuDetails.
- I fixed over 60+ deprecated warnings in the BillingClient and updated the code to use the latest Java syntax, such as lambdas.
- I resolved all warnings and updated some syntax in the InAppPurchasesModule.
- The `BillingResponseCode.SERVICE_TIMEOUT` has been deprecated, so I replaced it with `BillingResponseCode.NETWORK_ERROR`. Although these are not the same, we need to use the redundant error code since `BillingResponseCode.SERVICE_TIMEOUT` is now handled by `BillingResponseCode.SERVICE_UNAVAILABLE`.
- The method `mBillingClient.queryPurchaseHistoryAsync` is no longer supported, and Google recommends manually tracking purchase history if you need to support that feature. We use `getPurchaseHistoryAsync` in the Qeepsake app for purchase restoration, and I believe it will continue to function as expected. From my understanding, `mBillingClient.queryPurchaseHistoryAsync` is unnecessary because `mBillingClient.queryPurchaseAsync` will always return the valid purchase object.